### PR TITLE
feat: implement TravelRecommendationClient with OpenAI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,11 +16,13 @@ repositories {
 }
 
 val gsonVersion = "2.13.1"
+val openAiVersion = "0.18.2"
 
 dependencies {
     testImplementation(kotlin("test"))
 
     implementation("com.google.code.gson:gson:${gsonVersion}")
+    implementation("com.theokanning.openai-gpt3-java:service:${openAiVersion}")
 }
 
 tasks.test {

--- a/src/main/kotlin/adapter/out/openai/OpenAiTravelRecommendationClient.kt
+++ b/src/main/kotlin/adapter/out/openai/OpenAiTravelRecommendationClient.kt
@@ -1,18 +1,18 @@
 package adapter.out.openai
 
 import application.port.out.TravelRecommendationClient
-import com.theokanning.openai.service.OpenAiService
 import com.theokanning.openai.completion.chat.ChatCompletionRequest
 import com.theokanning.openai.completion.chat.ChatMessage
+import com.theokanning.openai.service.OpenAiService
 
-class OpenAiTravelRecommendationClient(
-    apiKey: String,
-    private val model: String = "gpt-3.5-turbo"
-) : TravelRecommendationClient {
+class OpenAiTravelRecommendationClient : TravelRecommendationClient {
 
+    private val apiKey = requireNotNull(System.getenv("OPENAI_API_KEY")) { "환경변수 OPENAI_API_KEY가 설정되지 않았습니다." }
+    private val model = "gpt-3.5-turbo"
     private val service = OpenAiService(apiKey)
 
     override fun getRecommendation(prompt: String): String {
+
         val message = ChatMessage("user", prompt)
         val request = ChatCompletionRequest.builder()
             .messages(listOf(message))

--- a/src/main/kotlin/adapter/out/openai/OpenAiTravelRecommendationClient.kt
+++ b/src/main/kotlin/adapter/out/openai/OpenAiTravelRecommendationClient.kt
@@ -1,0 +1,24 @@
+package adapter.out.openai
+
+import application.port.out.TravelRecommendationClient
+import com.theokanning.openai.service.OpenAiService
+import com.theokanning.openai.completion.chat.ChatCompletionRequest
+import com.theokanning.openai.completion.chat.ChatMessage
+
+class OpenAiTravelRecommendationClient(
+    apiKey: String,
+    private val model: String = "gpt-3.5-turbo"
+) : TravelRecommendationClient {
+
+    private val service = OpenAiService(apiKey)
+
+    override fun getRecommendation(prompt: String): String {
+        val message = ChatMessage("user", prompt)
+        val request = ChatCompletionRequest.builder()
+            .messages(listOf(message))
+            .model(model)
+            .build()
+        val response = service.createChatCompletion(request)
+        return response.choices.first().message.content.trim()
+    }
+}


### PR DESCRIPTION
## Summary
- implement `OpenAiTravelRecommendationClient` using OpenAI library
- add OpenAI dependency

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6873629ea820832b92218bb5d4e24364