### PR TITLE
Switch TravelRecommendationClient to Gemini API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,14 +16,14 @@ repositories {
 }
 
 val gsonVersion = "2.13.1"
-val generativeAiVersion = "0.1.0"
+val googleGenAiVersion = "1.8.0"
 val openAiVersion = "0.18.2"
 
 dependencies {
     testImplementation(kotlin("test"))
 
     implementation("com.google.code.gson:gson:${gsonVersion}")
-    implementation("com.google.ai.client:generativeai:${generativeAiVersion}")
+    implementation("com.google.genai:google-genai:${googleGenAiVersion}")
     implementation("com.theokanning.openai-gpt3-java:service:${openAiVersion}")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,12 +16,14 @@ repositories {
 }
 
 val gsonVersion = "2.13.1"
+val generativeAiVersion = "0.1.0"
 val openAiVersion = "0.18.2"
 
 dependencies {
     testImplementation(kotlin("test"))
 
     implementation("com.google.code.gson:gson:${gsonVersion}")
+    implementation("com.google.ai.client:generativeai:${generativeAiVersion}")
     implementation("com.theokanning.openai-gpt3-java:service:${openAiVersion}")
 }
 

--- a/src/main/kotlin/TravelRecommenderCli.kt
+++ b/src/main/kotlin/TravelRecommenderCli.kt
@@ -1,9 +1,9 @@
 import adapter.`in`.console.ConsoleRunner
-import adapter.out.openai.OpenAiTravelRecommendationClient
+import adapter.out.gemini.GeminiTravelRecommendationClient
 import application.service.TravelRecommendationService
 
 fun main() {
-    val client = OpenAiTravelRecommendationClient()
+    val client = GeminiTravelRecommendationClient()
     val service = TravelRecommendationService(client)
     val cli = ConsoleRunner(service)
     cli.run()

--- a/src/main/kotlin/adapter/out/gemini/GeminiTravelRecommendationClient.kt
+++ b/src/main/kotlin/adapter/out/gemini/GeminiTravelRecommendationClient.kt
@@ -1,18 +1,23 @@
 package adapter.out.gemini
 
 import application.port.out.TravelRecommendationClient
-import com.google.genai.GenerativeModel
-import com.google.genai.type.content
-import com.google.genai.type.text
+import com.google.genai.Client
+import com.google.genai.types.GenerateContentConfig
 
 class GeminiTravelRecommendationClient : TravelRecommendationClient {
 
-    private val apiKey = requireNotNull(System.getenv("GEMINI_API_KEY")) { "GEMINI_API_KEY가 필요합니다." }
-    private val model = GenerativeModel(modelName = "gemini-pro", apiKey = apiKey)
+    init {
+        requireNotNull(System.getenv("GEMINI_API_KEY")) { "GEMINI_API_KEY를 설정하세요." }
+    }
+
+    private val client = Client()
 
     override fun getRecommendation(prompt: String): String {
-        val request = content { text(prompt) }
-        val response = model.generateContent(request)
-        return response.text.trim()
+        val response = client.models.generateContent(
+            "gemini-2.5-flash",
+            prompt,
+            GenerateContentConfig.builder().responseMimeType("application/json").build()
+        )
+        return response.text()
     }
 }

--- a/src/main/kotlin/adapter/out/gemini/GeminiTravelRecommendationClient.kt
+++ b/src/main/kotlin/adapter/out/gemini/GeminiTravelRecommendationClient.kt
@@ -1,0 +1,18 @@
+package adapter.out.gemini
+
+import application.port.out.TravelRecommendationClient
+import com.google.ai.client.generativeai.GenerativeModel
+import com.google.ai.client.generativeai.type.content
+import com.google.ai.client.generativeai.type.text
+
+class GeminiTravelRecommendationClient : TravelRecommendationClient {
+
+    private val apiKey = requireNotNull(System.getenv("GEMINI_API_KEY")) { "GEMINI_API_KEY가 필요합니다." }
+    private val model = GenerativeModel(modelName = "gemini-pro", apiKey = apiKey)
+
+    override fun getRecommendation(prompt: String): String {
+        val request = content { text(prompt) }
+        val response = model.generateContent(request)
+        return response.text.trim()
+    }
+}

--- a/src/main/kotlin/adapter/out/gemini/GeminiTravelRecommendationClient.kt
+++ b/src/main/kotlin/adapter/out/gemini/GeminiTravelRecommendationClient.kt
@@ -1,9 +1,9 @@
 package adapter.out.gemini
 
 import application.port.out.TravelRecommendationClient
-import com.google.ai.client.generativeai.GenerativeModel
-import com.google.ai.client.generativeai.type.content
-import com.google.ai.client.generativeai.type.text
+import com.google.genai.GenerativeModel
+import com.google.genai.type.content
+import com.google.genai.type.text
 
 class GeminiTravelRecommendationClient : TravelRecommendationClient {
 

--- a/src/main/kotlin/application/service/TravelRecommendationService.kt
+++ b/src/main/kotlin/application/service/TravelRecommendationService.kt
@@ -12,40 +12,41 @@ class TravelRecommendationService(
 
     override fun recommend(command: TravelRecommendationCommand): TravelPlan {
         val prompt = buildPrompt(command)
+
+        println(prompt)
+        println()
+
         val recommendation = client.getRecommendation(prompt)
+
+        println(recommendation)
+
         return JsonParser.fromJson(recommendation)
     }
 
     private fun buildPrompt(command: TravelRecommendationCommand): String {
         return """
             아래 조건에 맞는 여행지를 추천해줘.
-            
-            조건
-            ----- start
             기간: ${command.startDate} ~ ${command.endDate}
-            지역: ${command.regionType}
-            스타일: ${command.style}
-            ----- end
-            
-            응답 형식은 아래와 같아. json이고, 다른 설명은 필요 없어. json만 주면 돼.
-            응답 형식
-            ----- start
+            지역: ${command.regionType.displayName}
+            스타일: ${command.style.displayName}
+            출력 형식
             {
-              "reason": "string",
+              "reason": "편안한 휴식을 위한 국내 여행지 추천입니다.",
               "destinations": [
                 {
-                  "name": "string",
-                  "reason": "string",
+                  "name": "제주도",
+                  "reason": "자연 경관과 편의 시설이 잘 어우러진 최고의 휴양지입니다.",
                   "schedules": [
                     {
-                      "day": number,
-                      "activities": ["string"]
+                      "day": 1,
+                      "activities": [
+                        "제주 공항 도착 후 호텔 체크인"
+                      ]
                     }
                   ]
                 }
               ]
             }
-            ----- end
         """.trimIndent()
     }
 }

--- a/src/main/kotlin/domain/model/TravelRegionType.kt
+++ b/src/main/kotlin/domain/model/TravelRegionType.kt
@@ -1,5 +1,5 @@
 package domain.model
 
-enum class TravelRegionType {
-    DOMESTIC, INTERNATIONAL
+enum class TravelRegionType(val displayName: String) {
+    DOMESTIC("국내"), INTERNATIONAL("해외")
 }

--- a/src/main/kotlin/domain/model/TravelStyle.kt
+++ b/src/main/kotlin/domain/model/TravelStyle.kt
@@ -1,6 +1,6 @@
 package domain.model
 
-enum class TravelStyle(val description: String) {
+enum class TravelStyle(val displayName: String) {
     SIGHTSEEING("관광"),
     RELAXATION("휴양"),
     ADVENTURE("모험/액티비티"),


### PR DESCRIPTION
## Summary
- replace OpenAI dependency with Google generative AI client
- add `GeminiTravelRecommendationClient` using the Gemini API
- update CLI to use the new client
- restore OpenAI client implementation and dependency

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687638f2854c832b81c99123095ea916